### PR TITLE
enable vault secret backend and uninstall script

### DIFF
--- a/secrets.yml
+++ b/secrets.yml
@@ -21,6 +21,12 @@
     - hashivault_status:
       register: 'vault_status'
 
+    - hashivault_secret_engine:
+        name: kv
+        state: enabled
+        backend: kv
+        options: version=1
+
     - hashivault_write:
         secret: '{{ secret }}'
         data:

--- a/uninstall_vault.yml
+++ b/uninstall_vault.yml
@@ -1,0 +1,36 @@
+---
+- hosts: localhost
+  become: yes
+
+  tasks:
+  - name: stop vault service
+    command: 'systemctl stop vault.service'
+
+  - name: delete vault binary
+    file: 
+      path: /usr/local/bin/vault
+      state: absent
+
+  - name: delete systemctl file
+    file: 
+      path: /etc/systemd/system/vault.service
+      state: absent
+
+  - name: delete tmp files
+    file: 
+      path: /tmp/vault
+      state: absent
+
+  - name: remove rootkey
+    file:
+      path: /home/student15/HashiVaultRole/rootKey
+      state: absent
+
+  - name: remove seal key
+    file:
+      path: /home/student15/HashiVaultRole/unsealKey
+      state: absent
+
+  - name: reload systemctl daemon
+    command: 'systemctl daemon-reload'
+


### PR DESCRIPTION
Added task to enable the kv secret backend in vault, this appears to be needed now. 
Also Created playbook to destroy the vault installation, as I found this useful when troubleshooting.